### PR TITLE
Fix OpenAI API key usage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ chat_gpt_system_prompt = os.environ.get("CHAT_GPT_SYSTEM_PROMPT")
 gpt_thread_max_count = int(os.environ.get("GPT_THREAD_MAX_COUNT"))
 
 slack_client = WebClient(token=slack_bot_token)
-openai.configuration.api_key = openai_api_key
+openai.api_key = openai_api_key
 
 def post_message(channel, text, thread_ts):
     slack_client.chat_postMessage(channel=channel, text=text, thread_ts=thread_ts)


### PR DESCRIPTION
## Summary
- correct API key assignment for OpenAI by setting `openai.api_key`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464e36ac6c8321bf0360b03a81c079