### PR TITLE
Fix missing import for HttpResponse

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import os
 import json
 from azure.functions import HttpRequest, HttpResponse
+import azure.functions as func
 from slack_sdk import WebClient
 from slack_sdk.signature import SignatureVerifier
 


### PR DESCRIPTION
## Summary
- add `import azure.functions as func`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464e3accbc8321aeeda89259bf35ef